### PR TITLE
Add ability to list columns without the default table prefix

### DIFF
--- a/classes/kohana/database.php
+++ b/classes/kohana/database.php
@@ -352,10 +352,10 @@ abstract class Kohana_Database {
 	 *
 	 * @param   string  table to get columns from
 	 * @param   string  column to search for
-         * @param   boolean whether to append the table prefix automatically or not
+         * @param   boolean whether to add the table prefix automatically or not
 	 * @return  array
 	 */
-	abstract public function list_columns($table, $like = NULL, $append_prefix = TRUE);
+	abstract public function list_columns($table, $like = NULL, $add_prefix = TRUE);
 
 	/**
 	 * Extracts the text between parentheses, if any.

--- a/classes/kohana/database.php
+++ b/classes/kohana/database.php
@@ -346,12 +346,16 @@ abstract class Kohana_Database {
 	 *
 	 *     // Get all name-related columns
 	 *     $columns = $db->list_columns('users', '%name%');
+         *
+         *     // Get the columns from a table that doesn't use the table prefix
+         *     $columns = $db->list_columns('users', NULL, FALSE);
 	 *
 	 * @param   string  table to get columns from
 	 * @param   string  column to search for
+         * @param   boolean whether to append the table prefix automatically or not
 	 * @return  array
 	 */
-	abstract public function list_columns($table, $like = NULL);
+	abstract public function list_columns($table, $like = NULL, $append_prefix = TRUE);
 
 	/**
 	 * Extracts the text between parentheses, if any.

--- a/classes/kohana/database.php
+++ b/classes/kohana/database.php
@@ -346,13 +346,13 @@ abstract class Kohana_Database {
 	 *
 	 *     // Get all name-related columns
 	 *     $columns = $db->list_columns('users', '%name%');
-         *
-         *     // Get the columns from a table that doesn't use the table prefix
-         *     $columns = $db->list_columns('users', NULL, FALSE);
+     *
+     *     // Get the columns from a table that doesn't use the table prefix
+     *     $columns = $db->list_columns('users', NULL, FALSE);
 	 *
 	 * @param   string  table to get columns from
 	 * @param   string  column to search for
-         * @param   boolean whether to add the table prefix automatically or not
+     * @param   boolean whether to add the table prefix automatically or not
 	 * @return  array
 	 */
 	abstract public function list_columns($table, $like = NULL, $add_prefix = TRUE);

--- a/classes/kohana/database/mysql.php
+++ b/classes/kohana/database/mysql.php
@@ -277,10 +277,10 @@ class Kohana_Database_MySQL extends Database {
 		return $tables;
 	}
 
-	public function list_columns($table, $like = NULL, $append_prefix = TRUE)
+	public function list_columns($table, $like = NULL, $add_prefix = TRUE)
 	{
 		// Quote the table name
-		$table = ($append_prefix === TRUE) ? $this->quote_table($table) : $table;
+		$table = ($add_prefix === TRUE) ? $this->quote_table($table) : $table;
 
 		if (is_string($like))
 		{

--- a/classes/kohana/database/mysql.php
+++ b/classes/kohana/database/mysql.php
@@ -277,10 +277,10 @@ class Kohana_Database_MySQL extends Database {
 		return $tables;
 	}
 
-	public function list_columns($table, $like = NULL)
+	public function list_columns($table, $like = NULL, $append_prefix = TRUE)
 	{
 		// Quote the table name
-		$table = $this->quote_table($table);
+		$table = ($append_prefix === TRUE) ? $this->quote_table($table) : $table;
 
 		if (is_string($like))
 		{

--- a/classes/kohana/database/pdo.php
+++ b/classes/kohana/database/pdo.php
@@ -153,7 +153,7 @@ class Kohana_Database_PDO extends Database {
 			array(':method' => __FUNCTION__, ':class' => __CLASS__));
 	}
 
-	public function list_columns($table, $like = NULL, $append_prefix = TRUE)
+	public function list_columns($table, $like = NULL, $add_prefix = TRUE)
 	{
 		throw new Kohana_Exception('Database method :method is not supported by :class',
 			array(':method' => __FUNCTION__, ':class' => __CLASS__));

--- a/classes/kohana/database/pdo.php
+++ b/classes/kohana/database/pdo.php
@@ -153,7 +153,7 @@ class Kohana_Database_PDO extends Database {
 			array(':method' => __FUNCTION__, ':class' => __CLASS__));
 	}
 
-	public function list_columns($table, $like = NULL)
+	public function list_columns($table, $like = NULL, $append_prefix = TRUE)
 	{
 		throw new Kohana_Exception('Database method :method is not supported by :class',
 			array(':method' => __FUNCTION__, ':class' => __CLASS__));


### PR DESCRIPTION
There are times when developers may want to pull a list of columns from a table that don't have the default table prefix. This change adds a third parameter to the _list_columns()_ method to allow that.
