### PR TITLE
3.2/master

### DIFF
--- a/classes/kohana/model/database.php
+++ b/classes/kohana/model/database.php
@@ -30,7 +30,7 @@ abstract class Kohana_Model_Database extends Model {
 	}
 
 	// Database instance
-	protected $_db = 'default';
+	protected $_db;
 
 	/**
 	 * Loads the database.
@@ -46,6 +46,11 @@ abstract class Kohana_Model_Database extends Model {
 		{
 			// Set the database instance name
 			$this->_db = $db;
+		}
+		
+		if ($this->_db === NULL)
+		{
+			$this->_db = Database::$default;
 		}
 
 		if (is_string($this->_db))

--- a/classes/kohana/session/database.php
+++ b/classes/kohana/session/database.php
@@ -47,7 +47,7 @@ class Kohana_Session_Database extends Session {
 		if ( ! isset($config['group']))
 		{
 			// Use the default group
-			$config['group'] = 'default';
+			$config['group'] = Database::$default;
 		}
 
 		// Load the database


### PR DESCRIPTION
Fixed issue #4289 - database models and sessions using 'default' as the default database group instead of the actual Database::$default value
