### PR TITLE
Updated guide to use case sensitive 'type' parameter.

### DIFF
--- a/guide/database/config.md
+++ b/guide/database/config.md
@@ -10,6 +10,7 @@ The database configuration file contains an array of configuration groups. The s
         'table_prefix' => string TABLE_PREFIX,
         'charset'      => string CHARACTER_SET,
     ),
+
 	
 Understanding each of these settings is important.
 
@@ -17,7 +18,7 @@ INSTANCE_NAME
 :  Connections can be named anything you want, but you should always have at least one connection called "default".
 
 DATABASE_TYPE
-:  One of the installed database drivers. Kohana comes with "mysql" and "pdo" drivers.  Drivers must extend the Database class.
+:  One of the installed database drivers. Kohana comes with "MySQL" and "pdo" drivers.  Drivers must extend the Database class.
 
 CONNECTION_ARRAY
 :  Specific driver options for connecting to your database. (Driver options are explained [below](#connection-settings).)
@@ -34,7 +35,7 @@ The example file below shows 2 MySQL connections, one local and one remote.
     (
         'default' => array
         (
-            'type'       => 'mysql',
+            'type'       => 'MySQL',
             'connection' => array(
                 'hostname'   => 'localhost',
                 'username'   => 'dbuser',
@@ -46,7 +47,7 @@ The example file below shows 2 MySQL connections, one local and one remote.
             'charset'      => 'utf8',
         ),
         'remote' => array(
-            'type'       => 'mysql',
+            'type'       => 'MySQL',
             'connection' => array(
                 'hostname'   => '55.55.55.55',
                 'username'   => 'remote_user',
@@ -58,6 +59,8 @@ The example file below shows 2 MySQL connections, one local and one remote.
             'charset'      => 'utf8',
         ),
     );
+
+Note that the 'type' parameter is case sensitive (eg 'MySQL', 'PDO').
 
 ## Connections and Instances
 


### PR DESCRIPTION
In kohana 3.3 the classes are case sensitive thus require classnames to be well written.
