### PR TITLE
fixed database::query() incorrect return value for NULL type

### DIFF
--- a/classes/Kohana/Database/MySQL.php
+++ b/classes/Kohana/Database/MySQL.php
@@ -217,11 +217,13 @@ class Kohana_Database_MySQL extends Database {
 				mysql_affected_rows($this->_connection),
 			);
 		}
-		else
+		elseif ($type === Database::UPDATE)
 		{
 			// Return the number of rows affected
 			return mysql_affected_rows($this->_connection);
 		}
+
+		return $result; 
 	}
 
 	public function datatype($type)

--- a/classes/Kohana/Database/PDO.php
+++ b/classes/Kohana/Database/PDO.php
@@ -193,11 +193,13 @@ class Kohana_Database_PDO extends Database {
 				$result->rowCount(),
 			);
 		}
-		else
+		elseif ($type === Database::UPDATE)
 		{
 			// Return the number of rows affected
 			return $result->rowCount();
 		}
+
+		return $result->errorCode() === '00000';
 	}
 
 	public function begin($mode = NULL)


### PR DESCRIPTION
`query()` return the execute result but not the rows affected that type isn't select / insert / update.
