### PR TITLE
PHP 5.5.x deprecates preg_replace() "/e" modifier causing scripts to crash with error ...

### DIFF
--- a/classes/database/pdo/sqlite.php
+++ b/classes/database/pdo/sqlite.php
@@ -1,0 +1,61 @@
+<?php defined('SYSPATH') or die('No direct script access.');
+/**
+ * PDO_SQLite database connection.
+ *
+ * @package    Kohana
+ * @author     Dinesh Shah and Tiger's Way
+ * @copyright  (c) 2010-2011 Dinesh Shah and Tiger's Way
+ * @license    http://kohanaphp.com/license.html
+ */
+class Database_PDO_SQLite extends Kohana_Database_PDO {
+
+	public function set_charset($charset)
+	{
+	}
+
+	public function list_tables($like = NULL)
+	{
+		if (is_string($like))
+		{
+			// Search for table names
+			$result = $this->query(Database::SELECT, 'SELECT name FROM SQLITE_MASTER WHERE type="table" AND name LIKE '.$this->quote($like).' ORDER BY name', FALSE);
+		}
+		else
+		{
+			// Find all table names
+			$result = $this->query(Database::SELECT, 'SELECT name FROM SQLITE_MASTER WHERE type="table" ORDER BY name', FALSE);
+		}
+
+		$tables = array();
+		foreach ($result as $row)
+		{
+			// Get the table name from the results
+			$tables[] = current($row);
+		}
+
+		return $tables;
+	}
+
+	public function list_columns($table, $like = NULL, $add_prefix = TRUE)
+	{
+		if (is_string($like))
+		{
+			throw new Kohana_Exception('Database method :method is not supported by :class',
+				array(':method' => __FUNCTION__, ':class' => __CLASS__));
+		}
+		
+		// Find all column names
+		$result = $this->query(Database::SELECT, 'PRAGMA table_info('.$table.')', FALSE);
+		
+		$columns = array();
+		foreach ($result as $row)
+		{
+			// Get the column name from the results
+			$columns[$row['name']] = $row['name'];
+		}
+
+		return $columns;
+	}
+
+} // End Database_PDOSQLite
+

--- a/classes/kohana/database.php
+++ b/classes/kohana/database.php
@@ -495,6 +495,10 @@ abstract class Kohana_Database {
 	 */
 	public function quote_column($column)
 	{
+
+                // Identifiers are escaped by repeating them
+                $escaped_identifier = $this->_identifier.$this->_identifier;
+                
 		if (is_array($column))
 		{
 			list($column, $alias) = $column;
@@ -515,15 +519,18 @@ abstract class Kohana_Database {
 			// Convert to a string
 			$column = (string) $column;
 
+                        $column = str_replace($this->_identifier, $escaped_identifier, $column);
+                        
 			if ($column === '*')
 			{
 				return $column;
 			}
-			elseif (strpos($column, '"') !== FALSE)
-			{
-				// Quote the column in FUNC("column") identifiers
-				$column = preg_replace('/"(.+?)"/e', '$this->quote_column("$1")', $column);
-			}
+//			elseif (strpos($column, '"') !== FALSE)
+//			{
+//				// Quote the column in FUNC("column") identifiers
+//				// preg_replace() is deprecated in PHP 5.5.x
+//				$column = preg_replace('/"(.+?)"/e', '$this->quote_column("$1")', $column);
+//			}
 			elseif (strpos($column, '.') !== FALSE)
 			{
 				$parts = explode('.', $column);

--- a/guide/database/config-sqlite.md
+++ b/guide/database/config-sqlite.md
@@ -1,0 +1,20 @@
+
+Sample Database Configuration for using PDO SQLite driver
+
+~~~
+return array
+(
+	'sqlite' => array(
+		'type'			=> 'pdo_sqlite',	// Make sure to use this name as type
+		'connection'	=> array(
+			'dsn'			=> 'sqlite:/path/to/database.sqlite',
+			'persistent'	=> FALSE,
+		),
+		'table_prefix'	=> '',
+		'charset'		=> 'utf8',
+		'caching'		=> FALSE,
+		'profiling'		=> TRUE,
+	),
+);
+~~~
+


### PR DESCRIPTION
...500

Kohana 3.2.2 with database module generates error 500 on PHP 5.5.x (tested on Ubuntu 13.10 with PHP 5.5.3)
