### PR TITLE
"AS" doesnt required for table aliases. Fixes #4598

### DIFF
--- a/classes/kohana/database.php
+++ b/classes/kohana/database.php
@@ -635,7 +635,7 @@ abstract class Kohana_Database {
 		if (isset($alias))
 		{
 			// Attach table prefix to alias
-			$table .= ' AS '.$this->_identifier.$this->table_prefix().$alias.$this->_identifier;
+			$table .= ' '.$this->_identifier.$this->table_prefix().$alias.$this->_identifier;
 		}
 
 		return $table;


### PR DESCRIPTION
See http://dev.kohanaframework.org/issues/4598
