### PR TITLE
Update Where.php

### DIFF
--- a/classes/Kohana/Database/Query/Builder/Where.php
+++ b/classes/Kohana/Database/Query/Builder/Where.php
@@ -133,7 +133,14 @@ abstract class Kohana_Database_Query_Builder_Where extends Database_Query_Builde
 	 */
 	public function and_where_close()
 	{
-		$this->_where[] = array('AND' => ')');
+		if(strtoupper($op) == 'IN' && empty($value))
+		{
+			$this->_where[] = array('AND' => array(DB::expr(1), '=', 0));
+		}
+		else
+		{
+			$this->_where[] = array('AND' => array($column, $op, $value));
+		}
 
 		return $this;
 	}
@@ -145,7 +152,14 @@ abstract class Kohana_Database_Query_Builder_Where extends Database_Query_Builde
 	 */
 	public function or_where_close()
 	{
-		$this->_where[] = array('OR' => ')');
+		if(strtoupper($op) == 'IN' && empty($value))
+		{
+			$this->_where[] = array('OR' => array(DB::expr(1), '=', 0));
+		}
+		else
+		{
+			$this->_where[] = array('OR' => array($column, $op, $value));
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
When

```
DB::select()->from('users')->where('id', 'IN', array(1,2,3));
```

Kohana Database will act as

```
SELECT * FROM `users` WHERE `id` IN (1,2,3)
```

But when

```
DB::select()->from('users')->where('id', 'IN', array());
```

The SQL:

```
SELECT * FROM `users` WHERE `id` IN ()
```

will run a fault.

So the change is
When

```
DB::select()->from('users')->where('id', 'IN', array());
```

The SQL will be:

```
SELECT * FROM `users` WHERE 1 = 0
```
