### PR TITLE
INSERT INTO syntax does not allow table aliasing

### DIFF
--- a/classes/Kohana/Database/Query/Builder/Insert.php
+++ b/classes/Kohana/Database/Query/Builder/Insert.php
@@ -31,7 +31,7 @@ class Kohana_Database_Query_Builder_Insert extends Database_Query_Builder {
 		if ($table)
 		{
 			// Set the inital table name
-			$this->_table = $table;
+			$this->table($table);
 		}
 
 		if ($columns)
@@ -47,11 +47,14 @@ class Kohana_Database_Query_Builder_Insert extends Database_Query_Builder {
 	/**
 	 * Sets the table to insert into.
 	 *
-	 * @param   mixed  $table  table name or array($table, $alias) or object
+	 * @param   string  $table  table name
 	 * @return  $this
 	 */
 	public function table($table)
 	{
+		if ( ! is_string($table))
+			throw new Kohana_Exception('INSERT INTO syntax does not allow table aliasing');
+
 		$this->_table = $table;
 
 		return $this;


### PR DESCRIPTION
Closes #79 

This PR disallows anything but a string for an `INSERT INTO` table name. Specifically it does not allow table name aliasing anymore.
