### PR TITLE
Kohana_Config_Database should extend Config_Database_Writer

### DIFF
--- a/classes/Kohana/Config/Database.php
+++ b/classes/Kohana/Config/Database.php
@@ -9,7 +9,7 @@
  * @copyright  (c) 2012 Kohana Team
  * @license    http://kohanaframework.org/license
  */
-class Kohana_Config_Database extends Kohana_Config_Database_Writer
+class Kohana_Config_Database extends Config_Database_Writer
 {
 
 }


### PR DESCRIPTION
`Kohana_Config_Database` should extend `Config_Database_Writer`
but not `Kohana_Config_Database_Writer`.

This is to ensure that changes to `Config_Database_Writer` affect
`Kohana_Config_Database` when transparently extending through
the Kohana CFS.
