### PR TITLE
Merge 3.2/master into 3.3/develop

### DIFF
--- a/classes/kohana/database/query/builder.php
+++ b/classes/kohana/database/query/builder.php
@@ -80,7 +80,7 @@ abstract class Kohana_Database_Query_Builder extends Database_Query {
 							// Convert "val = NULL" to "val IS NULL"
 							$op = 'IS';
 						}
-						elseif ($op === '!=')
+						elseif ($op === '!=' OR $op === '<>')
 						{
 							// Convert "val != NULL" to "valu IS NOT NULL"
 							$op = 'IS NOT';


### PR DESCRIPTION
Contains a fix by @biakaveron in the query builder to be able to handle both `<> NULL` and `!= NULL` as `IS NOT NULL`
