### PR TITLE
Fixed speed issues with values()

### DIFF
--- a/classes/Kohana/Database/Query/Builder/Insert.php
+++ b/classes/Kohana/Database/Query/Builder/Insert.php
@@ -89,8 +89,11 @@ class Kohana_Database_Query_Builder_Insert extends Database_Query_Builder {
 
 		// Get all of the passed values
 		$values = func_get_args();
-
-		$this->_values = array_merge($this->_values, $values);
+		
+		foreach ($values as $value)
+		{
+			$this->_values[] = $value;
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
When using values() with multiple sets of data, the array_merge() meant that there were performance issues with earlier versions of PHP (up to 5.5.6).

See http://micro-optimization.com/array_merge-vs-foreach-with-numeric-keys.html 

Issue here: https://github.com/kohana/core/issues/600
