### PR TITLE
support specifying flags in the datbase config

### DIFF
--- a/classes/Kohana/Database/MySQLi.php
+++ b/classes/Kohana/Database/MySQLi.php
@@ -43,6 +43,7 @@ class Kohana_Database_MySQLi extends Database {
 			'socket'   => '',
 			'port'     => 3306,
 			'ssl'      => NULL,
+			'flags'    => NULL,
 		));
 
 		// Prevent this information from showing up in traces
@@ -60,7 +61,7 @@ class Kohana_Database_MySQLi extends Database {
 					Arr::get($ssl, 'ca_dir_path'),
 					Arr::get($ssl, 'cipher')
 				);
-				$this->_connection->real_connect($hostname, $username, $password, $database, $port, $socket, MYSQLI_CLIENT_SSL);
+				$this->_connection->real_connect($hostname, $username, $password, $database, $port, $socket, MYSQLI_CLIENT_SSL | $flags);
 			}
 			else
 			{


### PR DESCRIPTION
I'm trying to deploy Kohana with Google Cloud SQL. With Cloud SQL, when using SSL they use a weird CN (see https://groups.google.com/d/msg/google-cloud-sql-discuss/4HNvmq7MpU4/cLI76b3OAwAJ ) and we need to specify some flags for the MySQLi connect.

This minimal patch allows the user to specify more flags if they want to.